### PR TITLE
fix: Add gunicorn dependency for Render deployment

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,3 +2,4 @@ asgiref==3.9.1
 Django==5.2.5
 djangorestframework==3.16.1
 sqlparse==0.5.3
+gunicorn


### PR DESCRIPTION
This change adds the 'gunicorn' package to the 'requirements.txt' file, resolving the "command not found" error during the Render deployment process. This is a critical fix to enable a successful backend build.