### PR TITLE
fix: Add missing djangorestframework-simplejwt dependency

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,3 +3,4 @@ Django==5.2.5
 djangorestframework==3.16.1
 sqlparse==0.5.3
 gunicorn
+djangorestframework-simplejwt


### PR DESCRIPTION
Fixes the failed deployment by adding the necessary djangorestframework-simplejwt dependency, which is required for authentication.