### PR TITLE
build: Fix deployment by adding CORS headers

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,4 @@ djangorestframework==3.16.1
 sqlparse==0.5.3
 gunicorn
 djangorestframework-simplejwt
+django-cors-headers


### PR DESCRIPTION
This adds the necessary django-cors-headers dependency to ensure the application starts correctly and handles cross-origin requests.