### PR TITLE
fix: Add Render URL to ALLOWED_HOSTS for successful deployment

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -28,7 +28,7 @@ SECRET_KEY = 'django-insecure-q)t)2@3sc1@+1^^z#y714&d%9*_v-1c-@x6-x3j*u^#_l7(2!p
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['muvi-flani-backend.onrender.com']
 
 
 # Application definition


### PR DESCRIPTION
This pull request resolves the DisallowedHost error encountered during the Render deployment. The muvi-flani-backend.onrender.com domain has been added to the ALLOWED_HOSTS list in settings.py to allow Django to serve requests from its production URL. This is a critical step to get the application fully online and accessible.