### PR TITLE
fix: Add localhost and 127.0.0.1 to ALLOWED_HOSTS

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -28,7 +28,9 @@ SECRET_KEY = 'django-insecure-q)t)2@3sc1@+1^^z#y714&d%9*_v-1c-@x6-x3j*u^#_l7(2!p
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ['muvi-flani-backend.onrender.com']
+# settings.py
+
+ALLOWED_HOSTS = ['muvi-flani-backend.onrender.com', '127.0.0.1', 'localhost']
 
 
 # Application definition


### PR DESCRIPTION
This pull request resolves the DisallowedHost error that occurs when running the Django server locally.

It adds 127.0.0.1 and localhost to the ALLOWED_HOSTS list in settings.py, which allows the backend to accept requests from a local development environment. The change also maintains the correct Render production host configuration.